### PR TITLE
Caption for geomodel entity figure

### DIFF
--- a/docs/features/geomodel.md
+++ b/docs/features/geomodel.md
@@ -17,7 +17,7 @@ to feed some physical simulators and export several data structure formats.
 ## GeoModel Constitutive Elements: GeoModelEntity
 
 A model is defined by its constitutive elements `RINGMesh::GeoModelEntity`. 
-There are two main kinds of entities:
+There are two main kinds of entities (Figure @fig:geomodel_entities):
 
  * Geometrical entities that define the geometry of the model through several dimensions:
      * Regions 
@@ -29,7 +29,8 @@ There are two main kinds of entities:
     * Interfaces
     * Contacts
 
-![alt text](images/geomodel_elements.svg)
+![Geomodel entities divided into the geometrical entities and the geological entities.
+Figure from Pellerin et al. (2017).](images/geomodel_elements.svg){#fig:geomodel_entities}
 
 We know that this is not a complete list. A lot of entities would be valuable to complete the model. 
 We strongly encourage people to contribute and complete these lists :)	


### PR DESCRIPTION
Add a caption the figure with a reference to Pellerin et al. 2007. The figure is also cited within the text.